### PR TITLE
コマンド周り修正(act関数の重複、useItem, defendの未定義、attackプロパティの名前衝突など）、コマンド関数の切り分けなど

### DIFF
--- a/src/character.js
+++ b/src/character.js
@@ -3,14 +3,15 @@ class Character extends Phaser.GameObjects.Sprite {
         super(scene, x, y, texture, frame);
 
         // キャラクターのステータスを定義する
-        this.name = status.name || "名無し";
-        this.hp = status.hp || 100;
-        this.attack = status.attack || 10;
-        this.defense = status.defense || 5;
+        this.status = {
+            name: status.name || "名無し",
+            hp: status.hp || 100,
+            attack: status.attack || 10,
+            defense: status.defense || 5,
+        };
 
-        // 行動スタックを保存するプロパティを追加する
+        // 行動スタックを保存するプロパティ
         this.actions = [];
-
 
         // キャラクターをシーンに追加する
         scene.add.existing(this);
@@ -20,37 +21,22 @@ class Character extends Phaser.GameObjects.Sprite {
     }
 
 
-     // 行動を追加するメソッド
+    // 行動を追加するメソッド
     addAction(action) {
-    this.actions.push(action);
+        this.actions.push(action);
     }
 
-    // 行動を実行するメソッド
-    act() {
-
-        // 行動スタックからアクションを取り出す
-    const action = this.popAction();
-
-    // アクションを実行する
-    switch (action) {
-        case "attack":
-        this.attack();
-        break;
-        case "defend":
-        this.defend();
-        break;
-        case "useItem":
-        this.useItem();
-        break;
-        }
-    }
-
-
+    // 行動を取り出すメソッド
+    popAction() {
+        const action = this.actions.pop();
+        return action;
+    } 
+    
     // キャラクターがダメージを受けるメソッド
     takeDamage(damage) {
-        this.hp -= damage;
-        console.log(`${this.name}は${damage}ダメージくらった`);
-        if (this.hp <= 0) {
+        this.status.hp -= damage;
+        console.log(`${this.status.name}は${damage}ダメージくらった`);
+        if (this.status.hp <= 0) {
             this.die();
         }
         this.updateStatusIndicator();
@@ -59,29 +45,80 @@ class Character extends Phaser.GameObjects.Sprite {
     // キャラクターが死亡するメソッド
     die() {
         // キャラクターを削除する処理をここに記述する
-        console.log(`${this.name}は死亡した`);
+        console.log(`${this.status.name}は死亡した`);
+    }
+
+    // キャラクターが回復するメソッド
+    restoreHealth(amount) {
+        this.status.hp += amount;
+        console.log(`${this.status.name}の体力が${amount}回復した`);
+        this.updateStatusIndicator();
     }
 
     //キャラクターが行動可能か判定するメソッド
-    canAct() {
+    canAct(action) {
         return true;
     }
-
-    // キャラクターが行動するメソッド
+    
+    // 行動を実行するメソッド
     act() {
-        if (this.canAct()) {
-            console.log(`${this.name}は行動した`);
-            // 攻撃対象のスプライトを取得
-            const target = this.scene.children.list.filter(sprite => (sprite.type === "Sprite") && (sprite.name !== this.name))[0];
-            target.takeDamage(this.attack);
+        // 行動スタックからアクションを取り出す
+        const action = this.popAction();
+
+        if (action == null) {
+            console.log(`${this.status.name}は行動スタックがないので行動できない!`);
+        } else if (this.canAct(action)) {
+            console.log(`${this.status.name}は行動した`);
+            // アクションを実行する
+            switch (action) {
+                case "attack":
+                    this.attack();
+                    break;
+                case "defend":
+                    this.defend();
+                    break;
+                case "useItem":
+                    this.useItem();
+                    break;
+                default:
+                    // 想定されていない値が来た場合の処理はここに書く
+                    console.log('想定されていない行動が入力されています');
+            }
         } else {
-            console.log(`${this.name}は行動できなかった`);
+            console.log(`${this.status.name}は行動できなかった`);
+        }
+
+        // キャラ行動終了時の共通処理はここに書く
+    }
+
+    // キャラが攻撃するメソッド
+    attack() {
+        // 攻撃対象のスプライトを取得（ここでは自分と名前が違う最初のスプライトを取得している）
+        const target = this.scene.children.list.filter(sprite => (sprite.type === "Sprite") && (sprite.status.name !== this.status.name))[0];
+        target.takeDamage(this.status.attack);
+    }
+
+    // キャラが防御するメソッド
+    defend() {
+        console.log(`${this.status.name}は防御している`);
+    }
+
+    // キャラがアイテムを使うメソッド
+    useItem() {
+        const itemId = 1;
+        console.log(`${this.status.name}はアイテムを使った!`);
+        switch (itemId) {
+            case 1:
+                this.restoreHealth(100);
+                break;
+            default:
+                console.log('しかし、何も起こらなかった');
         }
     }
 
     // ステータス表示を更新するメソッド
     updateStatusIndicator() {
-        this.hpIndicator.setText(this.hp);
+        this.hpIndicator.setText(this.status.hp);
     }
 }
 


### PR DESCRIPTION
Characterのステータスを`status`というひとつのオブジェクトにまとめた
例えばHPを取り出すには今まで`this.hp`としていたところを、`this.status.hp`とするようにした
これで、`attack()`関数と攻撃力ステータスの`attack`の名前の衝突がなくなった